### PR TITLE
Fix enumJsonFormat not to throw an exception on invalid input

### DIFF
--- a/composite-aeson/composite-aeson.cabal
+++ b/composite-aeson/composite-aeson.cabal
@@ -22,6 +22,7 @@ library
   ghc-options: -Wall -O2
   build-depends:
       base >= 4.7 && < 5
+    , mtl
     , aeson
     , aeson-better-errors
     , composite-base
@@ -65,6 +66,7 @@ test-suite composite-aeson-test
   ghc-options: -Wall -O2 -threaded -rtsopts -with-rtsopts=-N -fno-warn-orphans
   build-depends:
       base >= 4.7 && < 5
+    , mtl
     , aeson
     , aeson-better-errors
     , composite-base
@@ -89,6 +91,7 @@ test-suite composite-aeson-test
     , composite-aeson
     , hspec
   other-modules:
+      EnumSpec
       RecordSpec
       TupleSpec
   default-language: Haskell2010

--- a/composite-aeson/package.yaml
+++ b/composite-aeson/package.yaml
@@ -11,6 +11,7 @@ category:            Records
 
 dependencies:
   - base >= 4.7 && < 5
+  - mtl
   - aeson
   - aeson-better-errors
   - composite-base

--- a/composite-aeson/src/Composite/Aeson/Enum.hs
+++ b/composite-aeson/src/Composite/Aeson/Enum.hs
@@ -1,5 +1,6 @@
 module Composite.Aeson.Enum where
 
+import Control.Monad.Error.Class (throwError)
 import Composite.Aeson.Base (JsonFormat(JsonFormat), JsonProfunctor(JsonProfunctor))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.BetterErrors as ABE
@@ -48,6 +49,7 @@ enumMapJsonFormat lookupText lookupValue expectedText = JsonFormat $ JsonProfunc
     fromJson = do
       t <- ABE.asText
       case lookupText t of
-        Nothing -> fail $ "expected " ++ expectedText ++ ", not " ++ unpack t
+        Nothing -> throwError $ ABE.BadSchema [] $ ABE.FromAeson $
+                     "expected " ++ expectedText ++ ", not " ++ unpack t
         Just v  -> pure v
   

--- a/composite-aeson/test/EnumSpec.hs
+++ b/composite-aeson/test/EnumSpec.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE DeriveGeneric #-}
+module EnumSpec where
+
+import Data.Void (Void)
+import Data.Aeson (Value(String))
+import GHC.Generics (Generic)
+import Composite.Aeson.Base (JsonFormat, fromJsonWithFormat)
+import Composite.Aeson.Enum (enumJsonFormat)
+import qualified Data.Aeson.BetterErrors as ABE
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+data TestEnum = A | B deriving (Show, Eq, Ord, Generic)
+
+testEnumFormat :: JsonFormat Void TestEnum
+testEnumFormat = enumJsonFormat ""
+
+enumSuite :: Spec
+enumSuite =
+  describe "enumJsonFormat" $
+    describe "when input value does not match any of enum constructors" $
+      it "should return a parse error, not throw an exception" $
+        ABE.parseValue (fromJsonWithFormat testEnumFormat) (String "C")
+          `shouldBe` Left (ABE.BadSchema [] (ABE.FromAeson "expected one of A, B, not C"))

--- a/composite-aeson/test/Main.hs
+++ b/composite-aeson/test/Main.hs
@@ -1,9 +1,10 @@
 import RecordSpec (recordSuite)
 import TupleSpec (tupleSuite)
+import EnumSpec (enumSuite)
 import Test.Hspec (hspec)
 
 main :: IO ()
 main = hspec $ do
   recordSuite
   tupleSuite
-
+  enumSuite


### PR DESCRIPTION
`enumJsonFormat` currently throws an exception when encountering an input `String` that doesn't match any of the enum's constructors.

This pull request makes it return a `FromAeson` `ParseError`. Not an ideal solution, but certainly better than exception.