### PR TITLE
(Example) Add default id generation to sql schema

### DIFF
--- a/example/example.sql
+++ b/example/example.sql
@@ -7,13 +7,15 @@ grant all privileges on database example to example;
 \c example
 
 create type usertype as enum('Owner', 'Manager', 'Regular');
+create sequence user_ids;
 
 create table users (
-  id bigint not null primary key,
+  id integer primary key default nextval('user_ids'),
   login varchar not null,
   usertype usertype not null
 );
 
+alter sequence user_ids owner to example;
 alter table users owner to example;
 
 copy users (id, login, usertype) from stdin;
@@ -21,4 +23,3 @@ copy users (id, login, usertype) from stdin;
 2	Bob	Manager
 3	Cathy	Regular
 \.
-


### PR DESCRIPTION
Without it, opaleye tries to insert a null id into a "not null" column and fails